### PR TITLE
Link to homepage in topic pages

### DIFF
--- a/components/Layout/Footer/Footer.tsx
+++ b/components/Layout/Footer/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { AreWeHeadlessYetLogo } from '../../SVG';
 import { getYear } from '../../../lib';
 import styles from './Footer.module.scss';
@@ -22,7 +24,11 @@ export const Footer = ({ lastPublishedAt }: FooterProps) => (
             </div>
         </div>
         <div className={styles.logo}>
-            <AreWeHeadlessYetLogo color={variables.accentColor} />
+            <Link href="/">
+                <a>
+                    <AreWeHeadlessYetLogo color={variables.accentColor} />
+                </a>
+            </Link>
         </div>
     </footer>
 );

--- a/components/TopicPageHero/TopicPageHero.tsx
+++ b/components/TopicPageHero/TopicPageHero.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import styles from './TopicPageHero.module.scss';
 import { topicStatusImages } from '../../lib';
@@ -13,7 +14,11 @@ export const TopicPageHero = ({
 }: AreWeHeadlessYetTopicPage) => (
     <div className={styles.hero}>
         <div className={styles.logo}>
-            <HeadlessBird color={variables.textColor} />
+            <Link href="/">
+                <a>
+                    <HeadlessBird color={variables.textColor} />
+                </a>
+            </Link>
         </div>
         <div className={styles.hero__content}>
             <div className={styles.hero__status}>


### PR DESCRIPTION
Tom reported the following:
> There’s no link to the home page - if you landed on https://areweheadlessyet.wagtail.org/graphql, for example, you’d have to edit the URL to see what the site is all about.

This PR adds a link to the logo on the topic pages. I'm not sure how clear will it be that it's a link although.
