### PR TITLE
Mark Slack iconography as decorative (#49). Fix #48, #47

### DIFF
--- a/components/Layout/FooterSlackCTA/FooterSlackCTA.tsx
+++ b/components/Layout/FooterSlackCTA/FooterSlackCTA.tsx
@@ -2,7 +2,9 @@ import styles from './FooterSlackCTA.module.scss';
 
 export const FooterSlackCTA = () => (
     <div className={styles.container}>
-        <div className={styles.emoji}>👂</div>
+        <div className={styles.emoji} aria-hidden="true">
+            👂
+        </div>
         <div>
             <div className={styles.cta__text}>Hear the latest news…</div>
             <div className={styles.cta}>

--- a/components/Layout/HeadingSlackCTA/HeadingSlackCTA.tsx
+++ b/components/Layout/HeadingSlackCTA/HeadingSlackCTA.tsx
@@ -4,7 +4,7 @@ import variables from '../../../styles/variables.module.scss';
 
 export const HeadingSlackCTA = () => (
     <div className={styles.container}>
-        <div className={styles.logo}>
+        <div className={styles.logo} aria-hidden="true">
             <SlackLogo color={variables.textColor} />
         </div>
         <div className={styles.cta}>


### PR DESCRIPTION
- #48 
- #47 