### PR TITLE
Add header and footer landmarks (#50). Fix #44, #45

### DIFF
--- a/components/Layout/Footer/index.ts
+++ b/components/Layout/Footer/index.ts
@@ -1,3 +1,0 @@
-import Footer from './Footer';
-
-export default Footer;

--- a/components/Layout/Footer/types.ts
+++ b/components/Layout/Footer/types.ts
@@ -1,5 +1,0 @@
-type FooterProps = {
-    lastPublishedAt: string;
-};
-
-export default FooterProps;

--- a/components/Layout/FooterSlackCTA/FooterSlackCTA.module.scss
+++ b/components/Layout/FooterSlackCTA/FooterSlackCTA.module.scss
@@ -3,6 +3,7 @@
     align-self: flex-start;
     display: flex;
     position: relative;
+    width: fit-content;
     margin: 2rem 0;
     padding: 2rem 0;
 

--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -9,6 +9,10 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+}
+
+.header,
+.footer {
     position: relative;
 }
 

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import styles from './Layout.module.scss';
 import type LayoutProps from './types';
 import HeadingSlackCTA from './HeadingSlackCTA';
 import FooterSlackCTA from './FooterSlackCTA';
-import Footer from './Footer';
+import SubFooter from './SubFooter';
 import ThemeChanger from './ThemeChanger';
 
 const Layout = ({ title, children, lastPublishedAt }: LayoutProps) => (
@@ -31,13 +31,17 @@ const Layout = ({ title, children, lastPublishedAt }: LayoutProps) => (
             />
         </Head>
         <div className={styles.container}>
-            <main className={styles.main}>
-                <ThemeChanger />
+            <header className={styles.header}>
                 <HeadingSlackCTA />
+                <ThemeChanger />
+            </header>
+            <main className={styles.main}>
                 <div className={styles.content}>{children}</div>
-                <FooterSlackCTA />
-                <Footer lastPublishedAt={lastPublishedAt} />
             </main>
+            <footer className={styles.footer}>
+                <FooterSlackCTA />
+                <SubFooter lastPublishedAt={lastPublishedAt} />
+            </footer>
         </div>
     </>
 );

--- a/components/Layout/SubFooter/SubFooter.module.scss
+++ b/components/Layout/SubFooter/SubFooter.module.scss
@@ -1,4 +1,4 @@
-.footer {
+.subfooter {
     padding: 3rem 5rem 1rem 0;
     position: relative;
     line-height: 1.5;
@@ -9,7 +9,8 @@
         align-self: flex-end;
         display: flex;
         align-items: center;
-        width: auto;
+        width: fit-content;
+        float: right;
     }
 
     .copyright {

--- a/components/Layout/SubFooter/SubFooter.tsx
+++ b/components/Layout/SubFooter/SubFooter.tsx
@@ -1,14 +1,13 @@
 import Link from 'next/link';
-
 import { AreWeHeadlessYetLogo } from '../../SVG';
 import { getYear } from '../../../lib';
-import styles from './Footer.module.scss';
-import type FooterProps from './types';
+import styles from './SubFooter.module.scss';
+import type SubFooterProps from './types';
 import variables from '../../../styles/variables.module.scss';
 
-export const Footer = ({ lastPublishedAt }: FooterProps) => (
-    <footer className={styles.footer}>
-        <div className={styles.footer__text}>
+export const SubFooter = ({ lastPublishedAt }: SubFooterProps) => (
+    <div className={styles.subfooter}>
+        <div className={styles.subfooter__text}>
             <div>
                 <strong className={styles.copyright}>
                     © Are we headless yet?
@@ -30,7 +29,7 @@ export const Footer = ({ lastPublishedAt }: FooterProps) => (
                 </a>
             </Link>
         </div>
-    </footer>
+    </div>
 );
 
-export default Footer;
+export default SubFooter;

--- a/components/Layout/SubFooter/index.ts
+++ b/components/Layout/SubFooter/index.ts
@@ -1,0 +1,3 @@
+import SubFooter from './SubFooter';
+
+export default SubFooter;

--- a/components/Layout/SubFooter/types.ts
+++ b/components/Layout/SubFooter/types.ts
@@ -1,0 +1,5 @@
+type SubFooterProps = {
+    lastPublishedAt: string;
+};
+
+export default SubFooterProps;


### PR DESCRIPTION
This PR adds header and footer landmarks for better accessibility.

- #44 
  - Moved the `FooterSlackCTA` and "`Footer`" components to a separate `<footer>`, and to differentiate the main footer from the previous footer/sub-component, renamed instances of the old `Footer` to `SubFooter`. I'm assuming we don't want two `<footer>`s, so I changed the tag to a `<div>` in `SubFooter`.
- #45

